### PR TITLE
réglage problème issue#10 : les scénarios génériques se mettent à jour

### DIFF
--- a/src/abstraction/autres/TypeBien.java
+++ b/src/abstraction/autres/TypeBien.java
@@ -94,4 +94,15 @@ public class TypeBien {
 		return (this.Id.equals("") || this.Description.equals("") ||
 				this.intitule.equals(""));
 	}
+	
+	public boolean equals(Object o) {
+		boolean b = false ;
+		if (o instanceof TypeBien) {
+			TypeBien type = (TypeBien) o;
+			b= (type.getDescription().equals(this.getDescription())
+					&& type.getId().equals(this.getId()) && type.getIntitule()
+					.equals(this.getIntitule()));
+		}
+		return b;
+	}
 }

--- a/src/abstraction/modules/TypologieDesBiensSupports.java
+++ b/src/abstraction/modules/TypologieDesBiensSupports.java
@@ -297,4 +297,19 @@ public class TypologieDesBiensSupports extends Module {
 		}
 		return s ;
 	}
+	
+	public String getIdTypesNonRetenus(){
+		// On va rendre une chaine de caractère du type : "MAT,LOG, ..." avec
+		// MAT et LOG si ces types ont été non retenus par l'utilisateur
+		String s = "";
+		for (int i=0 ; i<this.tableau.size() ; i++){
+			if (!this.tableau.get(i).isRetenu()){
+				s+=this.tableau.get(i).getId() + ",";
+			}
+		}
+		if (s.length()>1){
+			s=s.substring(0, s.length()-1);
+		}
+		return s ;
+	}
 }


### PR DESCRIPTION
### Merci d'indiquer : 

* Numéro de l'issue : #10
* Titre de l'issue : Control du bouton de "Retenir" de « Typologies des biens supports »
* Description des changements (à l'intention d'EDF) :
Les scénarios génériques de mettent à jour dès qu'un type de bien support n'est plus retenu. Si on le retient de nouveau, les scénarios supprimés viennent se rajouter au début du tableau.

